### PR TITLE
Fix dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,23 +57,24 @@
     "react-dom": "^16.6.0",
     "react-test-renderer": "^16.6.0",
     "tslint": "^5.11.0",
-    "typescript": "^3.1.3"
-  },
-  "devDependencies": {
-    "@types/enzyme": "^3.1.14",
+    "typescript": "^3.1.3",
     "@types/express": "^4.16.0",
     "@types/jest": "^23.3.8",
     "@types/next": "^7.0.3",
     "@types/react": "^16.4.18",
-    "@types/react-test-renderer": "^16.0.3",
-    "enzyme-adapter-react-16": "^1.6.0",
+    "ts-node": "^7.0.1",
+        "@types/enzyme": "^3.1.14",
+        "@types/react-test-renderer": "^16.0.3",
+        "enzyme-adapter-react-16": "^1.6.0"
+  },
+  "devDependencies": {
+
     "husky": "^1.1.2",
     "jest": "^23.6.0",
     "lint-staged": "^8.0.0",
     "nodemon": "^1.18.5",
     "prettier": "^1.14.3",
     "ts-jest": "^23.10.4",
-    "ts-node": "^7.0.1",
     "tslint-config-airbnb": "^5.11.0",
     "tslint-config-prettier": "^1.15.0"
   }

--- a/package.json
+++ b/package.json
@@ -63,12 +63,11 @@
     "@types/next": "^7.0.3",
     "@types/react": "^16.4.18",
     "ts-node": "^7.0.1",
-        "@types/enzyme": "^3.1.14",
-        "@types/react-test-renderer": "^16.0.3",
-        "enzyme-adapter-react-16": "^1.6.0"
+    "@types/enzyme": "^3.1.14",
+    "@types/react-test-renderer": "^16.0.3",
+    "enzyme-adapter-react-16": "^1.6.0"
   },
   "devDependencies": {
-
     "husky": "^1.1.2",
     "jest": "^23.6.0",
     "lint-staged": "^8.0.0",


### PR DESCRIPTION
Due to incorrect dependencies splitting on heroku deployment we get next:

```
2018-11-03T11:52:38.403620+00:00 app[web.1]: "(server) /app/server.ts\nERROR in /app/server.ts(2,18):\nTS7016: Could not find a declaration file for module 'next'. '/app/node_modules/next/dist/server/next.js' implicitly has an 'any' type.\n  Try `npm install @types/next` if it exists or add a new declaration (.d.ts) file containing `declare module 'next';`" ],
2018-11-03T11:52:38.403621+00:00 app[web.1]: warnings: [] }
2018-11-03T11:52:41.267129+00:00 app[web.1]: error Command failed with exit code 1.
2018-11-03T11:52:41.480840+00:00 app[web.1]: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2018-11-03T11:52:43.807777+00:00 app[web.1]: npm ERR! code ELIFECYCLE
2018-11-03T11:52:43.813685+00:00 app[web.1]: npm ERR! errno 1
2018-11-03T11:52:43.902653+00:00 app[web.1]: npm ERR! cards-exporter@0.0.1 start: `yarn start:build && yarn start:server`
2018-11-03T11:52:43.902903+00:00 app[web.1]: npm ERR! Exit status 1
2018-11-03T11:52:43.903655+00:00 app[web.1]: npm ERR!
2018-11-03T11:52:43.903830+00:00 app[web.1]: npm ERR! Failed at the cards-exporter@0.0.1 start script.
2018-11-03T11:52:43.903979+00:00 app[web.1]: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
2018-11-03T11:52:44.065505+00:00 app[web.1]: 
2018-11-03T11:52:44.066568+00:00 app[web.1]: npm ERR! A complete log of this run can be found in:
2018-11-03T11:52:44.066765+00:00 app[web.1]: npm ERR!     /app/.npm/_logs/2018-11-03T11_52_43_997Z-debug.log
2018-11-03T11:52:44.323534+00:00 heroku[web.1]: Process exited with status 1
2018-11-03T11:52:44.340534+00:00 heroku[web.1]: State changed from starting to crashed
2018-11-03T11:52:44.342948+00:00 heroku[web.1]: State changed from crashed to starting
2018-11-03T11:52:56.943558+00:00 heroku[web.1]: Starting process with command `npm start`
2018-11-03T11:52:59.393555+00:00 app[web.1]: 
2018-11-03T11:52:59.393574+00:00 app[web.1]: > cards-exporter@0.0.1 start /app
2018-11-03T11:52:59.393576+00:00 app[web.1]: > yarn start:build && yarn start:server
2018-11-03T11:52:59.393577+00:00 app[web.1]: 
2018-11-03T11:53:00.035738+00:00 app[web.1]: yarn run v1.12.1
2018-11-03T11:53:00.140776+00:00 app[web.1]: $ NODE_ENV=production next build
2018-11-03T11:53:00.825789+00:00 heroku[router]: at=error code=H20 desc="App boot timeout" method=GET path="/" host=cards-exporter.herokuapp.com request_id=81b1177d-e61e-4252-a035-818011ad5b92 fwd="2.50.178.254" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T11:53:02.246603+00:00 app[web.1]: Starting type checking service...
2018-11-03T11:53:02.247630+00:00 app[web.1]: Using 1 worker with 2048MB memory limit
2018-11-03T11:53:02.263653+00:00 app[web.1]: [11:53:02 AM] Compiling server
2018-11-03T11:53:02.314735+00:00 app[web.1]: [11:53:02 AM] Compiling client
2018-11-03T11:53:02.787255+00:00 app[web.1]: > Using external babel configuration
2018-11-03T11:53:02.787434+00:00 app[web.1]: > Location: "/app/.babelrc"
2018-11-03T11:53:05.934670+00:00 app[web.1]: [11:53:05 AM] Compiled server in 4s
2018-11-03T11:53:28.923407+00:00 app[web.1]: [11:53:28 AM] Compiled client in 27s
2018-11-03T11:53:28.967818+00:00 app[web.1]: > Failed to build
2018-11-03T11:53:28.997584+00:00 app[web.1]: { Error: (server) /app/api/date/index.spec.ts
2018-11-03T11:53:28.997605+00:00 app[web.1]: ERROR in /app/api/date/index.spec.ts(4,1):
2018-11-03T11:53:28.997607+00:00 app[web.1]: TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.
2018-11-03T11:53:28.997609+00:00 app[web.1]: at /app/node_modules/next/dist/build/index.js:144:31
2018-11-03T11:53:28.997611+00:00 app[web.1]: at finalCallback (/app/node_modules/webpack/lib/MultiCompiler.js:247:12)
2018-11-03T11:53:28.997613+00:00 app[web.1]: at runWithDependencies.err (/app/node_modules/webpack/lib/MultiCompiler.js:270:6)
2018-11-03T11:53:28.997614+00:00 app[web.1]: at done (/app/node_modules/neo-async/async.js:2928:13)
2018-11-03T11:53:28.997616+00:00 app[web.1]: at runCompilers (/app/node_modules/webpack/lib/MultiCompiler.js:174:48)
2018-11-03T11:53:28.997617+00:00 app[web.1]: at err (/app/node_modules/webpack/lib/MultiCompiler.js:181:7)
2018-11-03T11:53:28.997619+00:00 app[web.1]: at compiler.run (/app/node_modules/webpack/lib/MultiCompiler.js:263:7)
2018-11-03T11:53:28.997620+00:00 app[web.1]: at finalCallback (/app/node_modules/webpack/lib/Compiler.js:204:39)
2018-11-03T11:53:28.997621+00:00 app[web.1]: at hooks.done.callAsync.err (/app/node_modules/webpack/lib/Compiler.js:253:14)
2018-11-03T11:53:28.997623+00:00 app[web.1]: at AsyncSeriesHook.eval [as callAsync] (eval at create (/app/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:33:1)
2018-11-03T11:53:28.997625+00:00 app[web.1]: at AsyncSeriesHook.lazyCompileHook (/app/node_modules/tapable/lib/Hook.js:154:20)
2018-11-03T11:53:28.997627+00:00 app[web.1]: at emitRecords.err (/app/node_modules/webpack/lib/Compiler.js:251:22)
2018-11-03T11:53:28.997628+00:00 app[web.1]: at /app/node_modules/graceful-fs/graceful-fs.js:43:10
2018-11-03T11:53:28.997630+00:00 app[web.1]: at FSReqCallback.oncomplete (fs.js:148:20)
2018-11-03T11:53:28.997631+00:00 app[web.1]: errors:
2018-11-03T11:53:28.997650+00:00 app[web.1]: [ "(server) /app/api/date/index.spec.ts\nERROR in /app/api/date/index.spec.ts(4,1):\nTS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.",
2018-11-03T11:53:28.997653+00:00 app[web.1]: "(server) /app/api/date/index.spec.ts\nERROR in /app/api/date/index.spec.ts(8,3):\nTS2304: Cannot find name 'beforeEach'.",
2018-11-03T11:53:28.997654+00:00 app[web.1]: "(server) /app/api/date/index.spec.ts\nERROR in /app/api/date/index.spec.ts(13,3):\nTS2582: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.",
2018-11-03T11:53:28.997658+00:00 app[web.1]: "(server) /app/api/date/index.spec.ts\nERROR in /app/api/date/index.spec.ts(14,16):\nTS2304: Cannot find name 'jest'.",
2018-11-03T11:53:28.997660+00:00 app[web.1]: "(server) /app/api/date/index.spec.ts\nERROR in /app/api/date/index.spec.ts(18,5):\nTS2304: Cannot find name 'expect'.",
2018-11-03T11:53:28.997661+00:00 app[web.1]: "(server) /app/api/date/index.spec.ts\nERROR in /app/api/date/index.spec.ts(19,5):\nTS2304: Cannot find name 'expect'.",
2018-11-03T11:53:28.997664+00:00 app[web.1]: "(server) /app/api/date/index.ts\nERROR in /app/api/date/index.ts(1,35):\nTS7016: Could not find a declaration file for module 'express'. '/app/node_modules/express/index.js' implicitly has an 'any' type.\n  Try `npm install @types/express` if it exists or add a new declaration (.d.ts) file containing `declare module 'express';`",
2018-11-03T11:53:28.997665+00:00 app[web.1]: "(server) /app/api/index.ts\nERROR in /app/api/index.ts(1,24):\nTS7016: Could not find a declaration file for module 'express'. '/app/node_modules/express/index.js' implicitly has an 'any' type.\n  Try `npm install @types/express` if it exists or add a new declaration (.d.ts) file containing `declare module 'express';`",
2018-11-03T11:53:28.997667+00:00 app[web.1]: `(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(1,10):\nTS2305: Module '"/app/enzyme"' has no exported member 'shallow'.`,
2018-11-03T11:53:28.997669+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(2,24):\nTS7016: Could not find a declaration file for module 'react'. '/app/node_modules/react/index.js' implicitly has an 'any' type.\n  Try `npm install @types/react` if it exists or add a new declaration (.d.ts) file containing `declare module 'react';`",
2018-11-03T11:53:28.997679+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(3,31):\nTS7016: Could not find a declaration file for module 'react-test-renderer'. '/app/node_modules/react-test-renderer/index.js' implicitly has an 'any' type.\n  Try `npm install @types/react-test-renderer` if it exists or add a new declaration (.d.ts) file containing `declare module 'react-test-renderer';`",
2018-11-03T11:53:28.997681+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(7,1):\nTS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.",
2018-11-03T11:53:28.997690+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(8,3):\nTS2582: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.",
2018-11-03T11:53:28.997692+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(10,5):\nTS2304: Cannot find name 'expect'.",
2018-11-03T11:53:28.997693+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(14,1):\nTS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.",
2018-11-03T11:53:28.997695+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(15,3):\nTS2582: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.",
2018-11-03T11:53:28.997696+00:00 app[web.1]: "(server) /app/pages/index.spec.tsx\nERROR in /app/pages/index.spec.tsx(18,5):\nTS2304: Cannot find name 'expect'.",
2018-11-03T11:53:28.997698+00:00 app[web.1]: "(server) /app/pages/index.tsx\nERROR in /app/pages/index.tsx(1,24):\nTS7016: Could not find a declaration file for module 'react'. '/app/node_modules/react/index.js' implicitly has an 'any' type.\n  Try `npm install @types/react` if it exists or add a new declaration (.d.ts) file containing `declare module 'react';`",
2018-11-03T11:53:28.997700+00:00 app[web.1]: "(server) /app/pages/index.tsx\nERROR in /app/pages/index.tsx(5,12):\nTS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.",
2018-11-03T11:53:28.997701+00:00 app[web.1]: "(server) /app/pages/index.tsx\nERROR in /app/pages/index.tsx(5,30):\nTS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.",
2018-11-03T11:53:28.997702+00:00 app[web.1]: "(server) /app/server.ts\nERROR in /app/server.ts(1,44):\nTS7016: Could not find a declaration file for module 'express'. '/app/node_modules/express/index.js' implicitly has an 'any' type.\n  Try `npm install @types/express` if it exists or add a new declaration (.d.ts) file containing `declare module 'express';`",
2018-11-03T11:53:28.997704+00:00 app[web.1]: "(server) /app/server.ts\nERROR in /app/server.ts(2,18):\nTS7016: Could not find a declaration file for module 'next'. '/app/node_modules/next/dist/server/next.js' implicitly has an 'any' type.\n  Try `npm install @types/next` if it exists or add a new declaration (.d.ts) file containing `declare module 'next';`" ],
2018-11-03T11:53:28.997706+00:00 app[web.1]: warnings: [] }
2018-11-03T11:53:29.442605+00:00 app[web.1]: error Command failed with exit code 1.
2018-11-03T11:53:29.446385+00:00 app[web.1]: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2018-11-03T11:53:30.084028+00:00 app[web.1]: npm ERR! code ELIFECYCLE
2018-11-03T11:53:30.087301+00:00 app[web.1]: npm ERR! errno 1
2018-11-03T11:53:30.122242+00:00 app[web.1]: npm ERR! cards-exporter@0.0.1 start: `yarn start:build && yarn start:server`
2018-11-03T11:53:30.122317+00:00 app[web.1]: npm ERR! Exit status 1
2018-11-03T11:53:30.122866+00:00 app[web.1]: npm ERR!
2018-11-03T11:53:30.123315+00:00 app[web.1]: npm ERR! Failed at the cards-exporter@0.0.1 start script.
2018-11-03T11:53:30.125610+00:00 app[web.1]: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
2018-11-03T11:53:30.257941+00:00 app[web.1]: 
2018-11-03T11:53:30.258500+00:00 app[web.1]: npm ERR! A complete log of this run can be found in:
2018-11-03T11:53:30.258684+00:00 app[web.1]: npm ERR!     /app/.npm/_logs/2018-11-03T11_53_30_197Z-debug.log
2018-11-03T11:53:30.413217+00:00 heroku[web.1]: Process exited with status 1
2018-11-03T11:53:30.429243+00:00 heroku[web.1]: State changed from starting to crashed
2018-11-03T11:53:32.942574+00:00 heroku[router]: at=error code=H20 desc="App boot timeout" method=GET path="/" host=cards-exporter.herokuapp.com request_id=e5192522-bc84-4f31-9958-c32cd4dd62bb fwd="93.85.39.54" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T11:53:55.636442+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=cards-exporter.herokuapp.com request_id=cbe0cb6d-5d7b-4e87-bc42-d82f6588d481 fwd="2.50.178.254" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T11:53:57.478036+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/favicon.ico" host=cards-exporter.herokuapp.com request_id=c0292adc-f06b-4660-8670-26564125d7bc fwd="2.50.178.254" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T11:57:19.747740+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=cards-exporter.herokuapp.com request_id=370ddc06-6f17-44b6-91a7-283f97e3c6b8 fwd="2.50.178.254" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T11:57:21.559262+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/favicon.ico" host=cards-exporter.herokuapp.com request_id=e78da0d9-406e-45c1-af51-edf1ce6c7c21 fwd="2.50.178.254" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T11:58:58.024532+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=cards-exporter.herokuapp.com request_id=70ed3277-2021-4c5e-aa63-4ee9983bd08d fwd="2.50.178.254" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T11:59:00.862531+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/favicon.ico" host=cards-exporter.herokuapp.com request_id=2c4bbcc0-1f3d-47b6-88a8-a9ed3ba3b70e fwd="2.50.178.254" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T12:02:23.527395+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=cards-exporter.herokuapp.com request_id=82de739d-b29c-4c6e-abb9-d7130f61f86e fwd="93.85.39.54" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T12:02:24.134245+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/favicon.ico" host=cards-exporter.herokuapp.com request_id=abf10e21-7cf2-4520-b947-901c91417cee fwd="93.85.39.54" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T12:02:33.318505+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=cards-exporter.herokuapp.com request_id=f0216f80-5f1a-4c7b-8433-5b5db985e68a fwd="93.85.39.54" dyno= connect= service= status=503 bytes= protocol=https
2018-11-03T12:02:33.533617+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/favicon.ico" host=cards-exporter.herokuapp.com request_id=8894bdf3-d388-4350-ba9a-b5300bc44356 fwd="93.85.39.54" dyno= connect= service= status=503 bytes= protocol=https
```

So dependencies were moved to dependencies section