### PR TITLE
fix jest coverage for all files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,21 @@
 module.exports = {
   globals: {
     "ts-jest": {
-      tsConfig: "jest.tsconfig.json"
+      tsConfig: "jest.tsconfig.json",
+      diagnostics: {
+        warnOnly: true
+      }
     }
   },
   moduleFileExtensions: ["js", "ts", "tsx"],
   moduleNameMapper: {
     "^~/(.*)": "<rootDir>/$1"
   },
+  collectCoverageFrom: [
+    "<rootDir>/**/*.{ts,tsx}",
+    "!**/node_modules/**",
+    "!**/typings/**"
+  ],
   setupTestFrameworkScriptFile: "<rootDir>/enzyme.js",
   silent: false,
   testEnvironment: "node",


### PR DESCRIPTION
Current coverage table of `yarn run coveralls` command 

![image](https://user-images.githubusercontent.com/32563455/50782838-31c93e00-12ba-11e9-92da-7dac9e71a030.png)
