### PR TITLE
add unique card id when export card

### DIFF
--- a/utils/cards.ts
+++ b/utils/cards.ts
@@ -4,6 +4,7 @@ import * as glob from "glob";
 import * as json5 from "json5";
 import * as util from "util";
 import { ICardDefinition } from "~/typings/ICardDefinition";
+import { getUniqueId } from "~/utils/getUniqueId";
 import { getRemoveCommand } from "./env";
 
 const globPromised = util.promisify(glob.Glob);
@@ -55,7 +56,7 @@ export const getCardData: (
   tags: string[];
 } = cardConfig => {
   const processor = require(`card-types/types/${cardConfig.type}`);
-  return processor(cardConfig);
+  return processor(cardConfig, getUniqueId());
 };
 
 export const getAllCards = (): Promise<ICardDefinition[]> =>

--- a/utils/getUniqueId.ts
+++ b/utils/getUniqueId.ts
@@ -1,0 +1,4 @@
+export const getUniqueId = (prefix = "xxx") =>
+  Buffer.from(`${prefix}-${Date.now()}-${Math.random()}`)
+    .toString("base64")
+    .replace(/[^a-zA-Z]/g, "");


### PR DESCRIPTION
These [changes](https://github.com/memory-cards/card-types/pull/11) requires random `cardId` when generating a deck. 