### PR TITLE
Add tests

### DIFF
--- a/api/cards/getDeck.spec.ts
+++ b/api/cards/getDeck.spec.ts
@@ -1,0 +1,65 @@
+import * as httpMocks from "node-mocks-http";
+import * as cards from "~/utils/cards";
+import * as decks from "~/utils/decks";
+import getDeckController from "./getDeck";
+
+describe("getDeckController", () => {
+  let req: httpMocks.MockRequest<any>;
+  let res: httpMocks.MockResponse<any>;
+  let mockFilterKnownCards: jest.SpyInstance<any>;
+  let mockGetAllCards: jest.SpyInstance<any>;
+  let generateDeckSpy: jest.SpyInstance<any>;
+  let sendFileSpy: jest.SpyInstance<any>;
+  let sendSpy: jest.SpyInstance<any>;
+
+  beforeEach(() => {
+    req = httpMocks.createRequest();
+    res = httpMocks.createResponse();
+    sendFileSpy = res.sendFile = jest.fn();
+    sendSpy = jest.spyOn(res, "send");
+    mockFilterKnownCards = jest.spyOn(cards, "filterKnownCards");
+    mockGetAllCards = jest.spyOn(cards, "getAllCards");
+    generateDeckSpy = jest.spyOn(decks, "generateDeck");
+  });
+  afterEach(() => {
+    generateDeckSpy.mockRestore();
+    mockGetAllCards.mockRestore();
+    mockFilterKnownCards.mockRestore();
+  });
+  it("calls pipe of functions and send file with result", async () => {
+    const getAllCardsMock: any[] = [];
+    const filterKnownCardsMock: any[] = [];
+    mockGetAllCards.mockReturnValue(Promise.resolve(getAllCardsMock));
+    mockFilterKnownCards.mockReturnValue(Promise.resolve(filterKnownCardsMock));
+
+    await getDeckController(req, res);
+    expect(mockGetAllCards).toHaveBeenCalled();
+    expect(mockFilterKnownCards).toHaveBeenCalledWith(getAllCardsMock);
+    expect(generateDeckSpy).toHaveBeenCalledWith(filterKnownCardsMock);
+    expect(sendFileSpy).toHaveBeenCalled();
+  });
+
+  it("sends error response of any fail 1", async () => {
+    mockGetAllCards.mockImplementation(() =>
+      Promise.reject(new Error("some strange error"))
+    );
+    await getDeckController(req, res);
+    expect(res.send).toHaveBeenCalled();
+    expect(res.send.mock.calls[0][0]).toMatchObject({
+      apiName: "cards/getDeck",
+      message: "some strange error"
+    });
+  });
+
+  it("sends error response of any fail 2", async () => {
+    mockFilterKnownCards.mockImplementation(() => {
+      throw new Error("some strange error 2");
+    });
+    await getDeckController(req, res);
+    expect(res.send).toHaveBeenCalled();
+    expect(res.send.mock.calls[0][0]).toMatchObject({
+      apiName: "cards/getDeck",
+      message: "some strange error 2"
+    });
+  });
+});

--- a/api/cards/getDeck.spec.ts
+++ b/api/cards/getDeck.spec.ts
@@ -44,8 +44,8 @@ describe("getDeckController", () => {
       Promise.reject(new Error("some strange error"))
     );
     await getDeckController(req, res);
-    expect(res.send).toHaveBeenCalled();
-    expect(res.send.mock.calls[0][0]).toMatchObject({
+    expect(sendSpy).toHaveBeenCalled();
+    expect(sendSpy.mock.calls[0][0]).toMatchObject({
       apiName: "cards/getDeck",
       message: "some strange error"
     });
@@ -56,8 +56,8 @@ describe("getDeckController", () => {
       throw new Error("some strange error 2");
     });
     await getDeckController(req, res);
-    expect(res.send).toHaveBeenCalled();
-    expect(res.send.mock.calls[0][0]).toMatchObject({
+    expect(sendSpy).toHaveBeenCalled();
+    expect(sendSpy.mock.calls[0][0]).toMatchObject({
       apiName: "cards/getDeck",
       message: "some strange error 2"
     });

--- a/api/cards/index.ts
+++ b/api/cards/index.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { Router } from "express";
 import getDeck from "./getDeck";
 import listCards from "./listCards";

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { Router } from "express";
 import cardsRouter from "./cards";
 import dateController from "./date";

--- a/package.json
+++ b/package.json
@@ -80,11 +80,11 @@
     "tsconfig-paths": "^3.6.0",
     "tsconfig-paths-jest": "^0.0.1",
     "tslint": "^5.11.0",
-    "typescript": "3.2.1"
+    "typescript": "3.2.1",
+    "jest": "^23.6.0"
   },
   "devDependencies": {
     "husky": "^1.1.2",
-    "jest": "^23.6.0",
     "lint-staged": "^8.0.0",
     "nodemon": "^1.18.5",
     "prettier": "^1.14.3",

--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import * as Sentry from "@sentry/node";
 import express, { Request, Response } from "express";
 import next from "next";


### PR DESCRIPTION
Some files were ignored for coverage. The reason - the only `not-really-awfull` way to test them is using `supertest` or similar. However, in this case, I prefer to have e2e tests, which takes the same effort but give more value from the testing perspective. 

Having tests which duplicate logic of imports/exports looks dummy for me.